### PR TITLE
Disable ol prefix linting

### DIFF
--- a/markdownlint/index.js
+++ b/markdownlint/index.js
@@ -13,6 +13,7 @@ const GLOBAL_CONFIG = {
   "no-inline-html": false,
   "no-trailing-punctuation": false,
   "no-blanks-blockquote": false,
+  "ol-prefix": false,
   "single-trailing-newline": false,
   "heading-style": {
     style: "atx",


### PR DESCRIPTION
We have ordered lists that are separated by paragraph reference code headings, so the [ol prefix validation](https://github.com/DavidAnson/markdownlint/blob/main/doc/md029.md) doesn't work correctly. Refs https://github.com/bountonw/translate/pull/266.