### PR TITLE
Stitch adjacent strings before transforming ellipsis

### DIFF
--- a/latex/filters/apply-forbidden-breaks.lua
+++ b/latex/filters/apply-forbidden-breaks.lua
@@ -21,32 +21,6 @@ table.sort(words, function (a, b)
     return utf8.len(a) > utf8.len(b)
 end)
 
-function Inlines (inlines)
-    local new_inlines = {}
-    local current_string = ""
-
-    -- logging.temp('inlines', inlines)
-    for i = 1, #inlines do
-        if inlines[i].t == "Str" then
-            current_string = current_string .. inlines[i].text
-        elseif inlines[i].t == "Space" or inlines[i].t == "SoftBreak" then
-            current_string = current_string .. " "
-        else 
-            if current_string then
-                table.insert(new_inlines, pandoc.Str(current_string))
-                current_string = ""
-            end
-            table.insert(new_inlines, inlines[i])
-        end
-    end
-    if current_string then
-        table.insert(new_inlines, pandoc.Str(current_string))
-    end
-
-    -- logging.temp('new_inlines', new_inlines)
-    return new_inlines
-end
-
 function Str (el)
     local t = {el.text}
     -- logging.temp('text', el.text)

--- a/latex/filters/stitch-adjacent-strings.lua
+++ b/latex/filters/stitch-adjacent-strings.lua
@@ -1,0 +1,27 @@
+-- local logging = require 'logging'
+
+function Inlines (inlines)
+    local new_inlines = {}
+    local current_string = ""
+
+    -- logging.temp('inlines', inlines)
+    for i = 1, #inlines do
+        if inlines[i].t == "Str" then
+            current_string = current_string .. inlines[i].text
+        elseif inlines[i].t == "Space" or inlines[i].t == "SoftBreak" then
+            current_string = current_string .. " "
+        else 
+            if current_string then
+                table.insert(new_inlines, pandoc.Str(current_string))
+                current_string = ""
+            end
+            table.insert(new_inlines, inlines[i])
+        end
+    end
+    if current_string then
+        table.insert(new_inlines, pandoc.Str(current_string))
+    end
+
+    -- logging.temp('new_inlines', new_inlines)
+    return new_inlines
+end

--- a/latex/filters/transform-ellipsis.lua
+++ b/latex/filters/transform-ellipsis.lua
@@ -1,5 +1,5 @@
 function Str (el)
   if string.match(el.text, '…') then
-      return pandoc.Str(string.gsub(el.text, "…", ". . ."))
+      return pandoc.Str(string.gsub(string.gsub(el.text, "…", " . . . "), "  ", " "))
   end
 end

--- a/latex/makefile
+++ b/latex/makefile
@@ -227,6 +227,7 @@ $(ICMLDIR)/%.icml:
 	pandoc \
 	  $(PREDIR)/$*.md \
 	  --from $(MARKDOWN_FORMAT) \
+	  --lua-filter $(FILDIR)/stitch-adjacent-strings.lua \
 	  --lua-filter $(FILDIR)/transform-ellipsis.lua \
 	  --lua-filter $(FILDIR)/apply-forbidden-breaks.lua \
 	  --lua-filter $(FILDIR)/remove-paragraph-code-headings.lua \


### PR DESCRIPTION
This allows replacing the unicode ellipsis with a psuedo-ellipsis with a single leading and trailing space. Refs https://github.com/bountonw/translate/pull/271.