### PR TITLE
Lint for improper Lao am vowel

### DIFF
--- a/markdownlint/custom-formatting-lao-am-vowel.js
+++ b/markdownlint/custom-formatting-lao-am-vowel.js
@@ -1,0 +1,31 @@
+import { applyCustomFormattingRules } from "./helpers.js";
+
+const customFormattingRules = [
+  {
+    name: "legacy AM vowel (ໍາ should be ຳ)",
+    test: (line) => {
+      if (!line) return -1;
+      
+      // Pattern to match Lao consonant + SARA AM (ໍ) + SARA AA (າ)
+      // This is the legacy form that should be converted to standard form
+      // Unicode ranges: Lao consonants (\u0E81-\u0EAE), SARA AM (\u0ECD), SARA AA (\u0EB2)
+      const legacyAmPattern = /([\u0E81-\u0EAE])\u0ECD\u0EB2/;
+      const match = line.match(legacyAmPattern);
+      
+      if (match) {
+        return line.indexOf(match[0]);
+      }
+      
+      return -1;
+    },
+  },
+];
+
+const CustomFormatting = {
+  names: ["custom-formatting-lao-am-vowel"],
+  description: "Lao AM vowel Unicode consistency rule",
+  tags: ["style", "unicode"],
+  function: applyCustomFormattingRules(customFormattingRules),
+};
+
+export default CustomFormatting;

--- a/markdownlint/custom-formatting-public.lo.js
+++ b/markdownlint/custom-formatting-public.lo.js
@@ -5,26 +5,26 @@ const customFormattingRules = [
     name: "legacy AM vowel (ໍາ should be ຳ)",
     test: (line) => {
       if (!line) return -1;
-      
+
       // Pattern to match Lao consonant + SARA AM (ໍ) + SARA AA (າ)
       // This is the legacy form that should be converted to standard form
       // Unicode ranges: Lao consonants (\u0E81-\u0EAE), SARA AM (\u0ECD), SARA AA (\u0EB2)
       const legacyAmPattern = /([\u0E81-\u0EAE])\u0ECD\u0EB2/;
       const match = line.match(legacyAmPattern);
-      
+
       if (match) {
         return line.indexOf(match[0]);
       }
-      
+
       return -1;
     },
   },
 ];
 
 const CustomFormatting = {
-  names: ["custom-formatting-lao-am-vowel"],
-  description: "Lao AM vowel Unicode consistency rule",
-  tags: ["style", "unicode"],
+  names: ["custom-formatting-public-lo"],
+  description: "Custom formatting rules (lo)",
+  tags: ["style"],
   function: applyCustomFormattingRules(customFormattingRules),
 };
 

--- a/markdownlint/index.js
+++ b/markdownlint/index.js
@@ -63,6 +63,19 @@ const CHECKS = [
     },
   },
   {
+    globPath: "./lo/**/03_public/",
+    customFormatting: "custom-formatting-lao-am-vowel.js",
+    config: {
+      default: false,
+    },
+  },
+  {
+    globPath: "./lo/assets/dictionaries/",
+    customFormatting: "custom-formatting-lao-am-vowel.js",
+    config: {
+      default: false,
+    },
+  {
     globPath: "./th/**/",
     customFormatting: "custom-formatting.th.js",
     config: {

--- a/markdownlint/index.js
+++ b/markdownlint/index.js
@@ -64,17 +64,11 @@ const CHECKS = [
   },
   {
     globPath: "./lo/**/03_public/",
-    customFormatting: "custom-formatting-lao-am-vowel.js",
+    customFormatting: "custom-formatting-public.lo.js",
     config: {
       default: false,
     },
   },
-  {
-    globPath: "./lo/assets/dictionaries/",
-    customFormatting: "custom-formatting-lao-am-vowel.js",
-    config: {
-      default: false,
-    },
   {
     globPath: "./th/**/",
     customFormatting: "custom-formatting.th.js",


### PR DESCRIPTION
@mattleff The two components of the AM vowel are stand alone characters in Lao. So for จำ คำ ทำ the Am has a little circle and the sara Ah. Lao has a Sara Am, but unfortunately, it can be typed with the two components separately. I want clean files so that dictionary lookups (which effect type setting) can be standardized. So basically

- Standard form: ຄຳ (U+0E04 + U+0ECD SARA AM) = Good
- Legacy form: ຄໍາ (U+0E04 + U+0ECD + U+0EB2) = Bad and should be forbidden.