### PR TITLE
Add double reference code validation rule

### DIFF
--- a/markdownlint/custom-formatting-reference-code.js
+++ b/markdownlint/custom-formatting-reference-code.js
@@ -25,6 +25,15 @@ const CustomFormatting = {
         return -1;
       },
     },
+    {
+      name: "double reference code",
+      test: (line, params) => {
+        if (line && line.search(/\}\s*\{/) >= 0) {
+          return line.length - 1;
+        }
+        return -1;
+      },
+    },
   ]),
 };
 


### PR DESCRIPTION
@mattleff I found several back to back EGW tags in the code base and would like to protect against this. Is the suggested update correct? You can merge when ready. Will this conflict with the tooling update on the typesetting branch? Since this isn't a critical update, we could just continue updating tooling in the typesetting branch which I hope to clean up and merge in a couple of weeks. Of if it isn't a conflict, we can merge to main which would give us the protection.