### PR TITLE
Allow thai{} and prevent double ref codes

### DIFF
--- a/markdownlint/custom-formatting.js
+++ b/markdownlint/custom-formatting.js
@@ -23,7 +23,11 @@ const customFormattingRules = [
   },
   {
     name: "no space before '{'",
-    regexp: /\S{/,
+    regexp: /[^\sthai]{/,
+  },
+  {
+    name: "double ref codes",
+    regexp: /\}\s*\{/,
   },
   {
     name: "missing space before opening curly quotes",


### PR DESCRIPTION
Addresses https://github.com/bountonw/translate/pull/648#issuecomment-3349344487 and replaces https://github.com/bountonw/translate-tooling/pull/99