### PR TITLE
Exclude numbered-stage assets dirs (NN_assets) from linting

### DIFF
--- a/textlint/index.js
+++ b/textlint/index.js
@@ -55,6 +55,7 @@ const BASE_EXCLUDES = [
   "!**/README.md",
   "!**/tests/**",
   "!**/assets/**",
+  "!**/[0-9][0-9]_assets/**", // numbered-stage assets dirs (e.g. 04_assets)
   "!**/AA/**", // TODO: fix up the AA errors and re-enable this check for AA
 ];
 


### PR DESCRIPTION
## Problem

The lint scope already excludes `assets/` directories (`!**/assets/**` in `BASE_EXCLUDES`), but newer books use the numbered-stage convention `04_assets/` for non-content build files. That glob doesn't match `04_assets/`, so Typst **template/source** files placed there get linted as if they were translation prose.

`th/SJ` is the first book to put `.typ` source under `04_assets/template/`, which surfaced the gap as ~130 false-positive lint errors on its PR.

## Why they're false positives

The lightweight Typst plugin only parses the *chapter-content* subset of Typst. It skips `#let` to end of line, so multi-line `#let name(...) = { ... }` function bodies get mis-parsed as Thai prose paragraphs, producing:

- `missing space after numbers` on length literals (`1.7em` -> `7e`, `0pt`, `36mm`, `4pt`)
- `invalid spacing` on code-line ends followed by the next line's indentation
- `reference-code-typ` because those phantom paragraphs lack `#EGW[\{...\}]` citations

None are fixable without breaking valid Typst.

## Fix

Add `!**/[0-9][0-9]_assets/**` to `BASE_EXCLUDES`, matching the existing `assets/` exclusion's intent under the numbered-stage convention. Covers every book's `04_assets` dir.

Verified locally: `npm run lint` -> **All clear!** (no other files affected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)